### PR TITLE
Tpoignonec optionnal cmd msg + other features

### DIFF
--- a/pytrollercli/pytrollercli/resource/include/pytroller.hpp.em
+++ b/pytrollercli/pytrollercli/resource/include/pytroller.hpp.em
@@ -73,15 +73,11 @@ public:
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 protected:
-
   void declare_parameters();
   controller_interface::CallbackReturn read_parameters();
 
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
-
-  std::vector<std::string> joint_names_;
-  std::string interface_name_;
 
   std::vector<std::string> command_interface_types_;
   std::unordered_map<std::string, double> states_;

--- a/pytrollercli/pytrollercli/resource/package/CMakeLists.txt.em
+++ b/pytrollercli/pytrollercli/resource/package/CMakeLists.txt.em
@@ -44,7 +44,7 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/@(pytroller_name)_logic.pyx
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/@(pytroller_name)_logic_impl.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/script/@(pytroller_name)_logic_impl.py
 )
 
 # Copy the header file into the include directory

--- a/pytrollercli/pytrollercli/resource/package/CMakeLists.txt.em
+++ b/pytrollercli/pytrollercli/resource/package/CMakeLists.txt.em
@@ -44,6 +44,7 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/@(pytroller_name)_logic.pyx
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/@(pytroller_name)_logic_impl.py
 )
 
 # Copy the header file into the include directory

--- a/pytrollercli/pytrollercli/resource/script/pytroller_logic_impl.py.em
+++ b/pytrollercli/pytrollercli/resource/script/pytroller_logic_impl.py.em
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def pytroller_logic_impl(states, commands, msg, params):
+def pytroller_logic_impl(period, states, commands, msg, params):
 
   return commands

--- a/pytrollercli/pytrollercli/resource/src/pytroller.cpp.em
+++ b/pytrollercli/pytrollercli/resource/src/pytroller.cpp.em
@@ -216,12 +216,6 @@ controller_interface::CallbackReturn @(pytroller_class)::read_parameters()
   }
   params_ = param_listener_->get_params();
 
-  if (params_.joints.empty())
-  {
-    RCLCPP_ERROR(get_node()->get_logger(), "'joints' parameter was empty");
-    return controller_interface::CallbackReturn::ERROR;
-  }
-
   if (params_.interface_full_names.empty())
   {
     RCLCPP_ERROR(get_node()->get_logger(), "'interface_full_names' parameter was empty");

--- a/pytrollercli/pytrollercli/resource/src/pytroller.cpp.em
+++ b/pytrollercli/pytrollercli/resource/src/pytroller.cpp.em
@@ -156,7 +156,7 @@ controller_interface::CallbackReturn @(pytroller_class)::on_deactivate(
 }
 
 controller_interface::return_type @(pytroller_class)::update(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & period)
 {
   // update parameters if changed
   if (param_listener_->is_old(params_)) {
@@ -187,7 +187,7 @@ controller_interface::return_type @(pytroller_class)::update(
   }
 
   // run cython function
-  if (@(pytroller_name)_logic(states_, commands_, message, params_)) {
+  if (@(pytroller_name)_logic(period.seconds(), states_, commands_, message, params_)) {
     RCLCPP_ERROR_THROTTLE(
       get_node()->get_logger(), *(get_node()->get_clock()), 1000,
       "@(pytroller_name) logic failed.");

--- a/pytrollercli/pytrollercli/resource/src/pytroller_logic.pyx.em
+++ b/pytrollercli/pytrollercli/resource/src/pytroller_logic.pyx.em
@@ -31,10 +31,13 @@ from rclpy.serialization import deserialize_message
 
 cdef public int @(pytroller_name)_logic(unordered_map[string, double] states, unordered_map[string, double] & commands, vector[int] & msg, Params param):
   try:
-    mt = param.command_topic_type.decode("utf-8").split('/')
-    messagetype = getattr(importlib.import_module('.'.join(mt[:2])), mt[-1])
-    command_message = deserialize_message(bytes(msg), type(messagetype()))
-
+    command_message = None
+    # Read command msg if applicable (i.e., there is one...)
+    if (len(msg) > 0):
+      mt = param.command_topic_type.decode("utf-8").split('/')
+      messagetype = getattr(importlib.import_module('.'.join(mt[:2])), mt[-1])
+      command_message = deserialize_message(bytes(msg), type(messagetype()))
+    # Either way, call python logic
     (&commands)[0] = pytroller_logic_impl(states, commands, command_message, param)
   except Exception as error:
     print("An exception occurred:", error)

--- a/pytrollercli/pytrollercli/resource/src/pytroller_logic.pyx.em
+++ b/pytrollercli/pytrollercli/resource/src/pytroller_logic.pyx.em
@@ -29,7 +29,13 @@ include "@(pytroller_name)_parameters.pxd"
 import importlib
 from rclpy.serialization import deserialize_message
 
-cdef public int @(pytroller_name)_logic(unordered_map[string, double] states, unordered_map[string, double] & commands, vector[int] & msg, Params param):
+cdef public int @(pytroller_name)_logic(
+  double period,
+  unordered_map[string, double] states,
+  unordered_map[string, double] & commands,
+  vector[int] & msg,
+  Params param
+):
   try:
     command_message = None
     # Read command msg if applicable (i.e., there is one...)
@@ -38,7 +44,7 @@ cdef public int @(pytroller_name)_logic(unordered_map[string, double] states, un
       messagetype = getattr(importlib.import_module('.'.join(mt[:2])), mt[-1])
       command_message = deserialize_message(bytes(msg), type(messagetype()))
     # Either way, call python logic
-    (&commands)[0] = pytroller_logic_impl(states, commands, command_message, param)
+    (&commands)[0] = pytroller_logic_impl(period, states, commands, command_message, param)
   except Exception as error:
     print("An exception occurred:", error)
     return -1

--- a/pytrollercli/pytrollercli/resource/src/pytroller_parameters.yaml.em
+++ b/pytrollercli/pytrollercli/resource/src/pytroller_parameters.yaml.em
@@ -7,11 +7,10 @@
   command_topic_name: {
     type: string,
     default_value: "",
-    description: "Optionnal. Name of the subscribed command topic"
+    description: "Optional. Name of the subscribed command topic"
   }
   command_topic_type: {
     type: string,
     default_value: "",
-    description: "Optionnal. Type of the subscribed command topic"
+    description: "Optional. Type of the subscribed command topic"
   }
-

--- a/pytrollercli/pytrollercli/resource/src/pytroller_parameters.yaml.em
+++ b/pytrollercli/pytrollercli/resource/src/pytroller_parameters.yaml.em
@@ -11,11 +11,11 @@
   }
   command_topic_name: {
     type: string,
-    default_value: "~/commands",
+    default_value: "",
     description: "Name of the subscribed command topic"
   }
   command_topic_type: {
     type: string,
-    default_value: "std_msgs/msg/Float64MultiArray",
+    default_value: "",
     description: "Type of the subscribed command topic"
   }

--- a/pytrollercli/pytrollercli/resource/src/pytroller_parameters.yaml.em
+++ b/pytrollercli/pytrollercli/resource/src/pytroller_parameters.yaml.em
@@ -1,21 +1,17 @@
 @(pytroller_name):
-  joints: {
+  interface_full_names: {
     type: string_array,
     default_value: [],
-    description: "Name of the joints to control",
-  }
-  interface_name: {
-    type: string,
-    default_value: "",
-    description: "Name of the interface to command",
+    description: "Name (WARNING, full names, e.g., 'joint_1/effort') of the interface(s) to command",
   }
   command_topic_name: {
     type: string,
     default_value: "",
-    description: "Name of the subscribed command topic"
+    description: "Optionnal. Name of the subscribed command topic"
   }
   command_topic_type: {
     type: string,
     default_value: "",
-    description: "Type of the subscribed command topic"
+    description: "Optionnal. Type of the subscribed command topic"
   }
+

--- a/pytrollercli/pytrollercli/resource/test/test_params.yaml.em
+++ b/pytrollercli/pytrollercli/resource/test/test_params.yaml.em
@@ -1,13 +1,15 @@
 load_@(pytroller_name):
   ros__parameters:
-    joints: ["joint1", "joint2"]
-    interface_name: "position"
+    interface_full_names:
+     - "joint1/position"
+     - "joint2/position"
     command_topic_name: "~/commands"
     command_topic_type: "std_msgs/msg/Float64MultiArray"
 
 test_@(pytroller_name):
   ros__parameters:
-    joints: ["joint1", "joint2"]
-    interface_name: "position"
+    interface_full_names:
+     - "joint1/position"
+     - "joint2/position"
     command_topic_name: "~/commands"
     command_topic_type: "std_msgs/msg/Float64MultiArray"


### PR DESCRIPTION
__Feature:__

- Optionnal command msg
- Make ROS2 control `period` variable available to the python logic
- Use parameter `interface_full_names`instead of `joints`and `interface_name`:
```yaml
<controller_name>
  ros__parameters:
    joints:
      - joint_1
      - joint_2
    interface_name:
      - velocity
```

becomes 

```yaml
<controller_name>
  ros__parameters:
    interface_full_names:
      - joint_1/velocity
      - joint_2/velocity
```
which allows for mixed/custom interface types (e.g., useful for force sensors)
- CMake monitoring of the script